### PR TITLE
Sprite multiplexing fix

### DIFF
--- a/esemsx3/src/video/vdp.vhd
+++ b/esemsx3/src/video/vdp.vhd
@@ -405,7 +405,8 @@ ARCHITECTURE RTL OF VDP IS
             -- JP: 描画する事もできるので、このビットが必要
             SPCOLOROUT                  : OUT   STD_LOGIC;
             -- OUTPUT COLOR
-            SPCOLORCODE                 : OUT   STD_LOGIC_VECTOR(  3 DOWNTO 0 )
+            SPCOLORCODE                 : OUT   STD_LOGIC_VECTOR(  3 DOWNTO 0 );
+            REG_R9_Y_DOTS               : IN    STD_LOGIC
         );
     END COMPONENT;
 
@@ -1664,7 +1665,8 @@ BEGIN
         PRAMDAT                     => PRAMDAT,
         PRAMADR                     => PRAMADRSPRITE,
         SPCOLOROUT                  => SPRITECOLOROUT,
-        SPCOLORCODE                 => COLORCODESPRITE
+        SPCOLORCODE                 => COLORCODESPRITE,
+        REG_R9_Y_DOTS               => REG_R9_Y_DOTS
     );
 
     -----------------------------------------------------------------------------

--- a/esemsx3/src/video/vdp_register.vhd
+++ b/esemsx3/src/video/vdp_register.vhd
@@ -397,7 +397,7 @@ BEGIN
                 WHEN "01"       => -- PORT#1 (0x99): READ STATUS REGISTER
                     CASE( VDPR15STATUSREGNUM )IS
                     WHEN "0000" => -- READ S#0
-                        DBI <= (NOT REQ_VSYNC_INT_N) & (VDPS0SPOVERMAPPED AND REQ_VSYNC_INT_N) & VDPS0SPCOLLISIONINCIDENCE & VDPS0SPOVERMAPPEDNUM;
+                        DBI <= (NOT REQ_VSYNC_INT_N) & VDPS0SPOVERMAPPED & VDPS0SPCOLLISIONINCIDENCE & VDPS0SPOVERMAPPEDNUM;
                     WHEN "0001" => -- READ S#1
                         DBI <= "00" & VDP_ID & (NOT REQ_HSYNC_INT_N);
                     WHEN "0010" => -- READ S#2

--- a/esemsx3/src/video/vdp_sprite.vhd
+++ b/esemsx3/src/video/vdp_sprite.vhd
@@ -224,7 +224,8 @@ ENTITY VDP_SPRITE IS
         -- JP: 描画する事もできるので、このビットが必要
         SPCOLOROUT                  : OUT   STD_LOGIC;
         -- OUTPUT COLOR
-        SPCOLORCODE                 : OUT   STD_LOGIC_VECTOR(  3 DOWNTO 0 )
+        SPCOLORCODE                 : OUT   STD_LOGIC_VECTOR(  3 DOWNTO 0 );
+		REG_R9_Y_DOTS               : IN    STD_LOGIC
     );
 END VDP_SPRITE;
 
@@ -343,6 +344,8 @@ ARCHITECTURE RTL OF VDP_SPRITE IS
     SIGNAL W_SP_OFF                 : STD_LOGIC;
     SIGNAL W_SP_OVERMAP             : STD_LOGIC;
     SIGNAL W_ACTIVE                 : STD_LOGIC;
+    SIGNAL SPWINDOW_Y               : STD_LOGIC;
+
 BEGIN
 
     PVDPS0RESETACK          <= FF_VDPS0RESETACK;
@@ -543,6 +546,24 @@ BEGIN
     W_ACTIVE        <=  BWINDOW_Y;
 
     -----------------------------------------------------------------------------
+    -- [SPWINDOW_Y]
+    -----------------------------------------------------------------------------
+    PROCESS( RESET, CLK21M )
+    BEGIN
+        IF( RESET = '1' )THEN
+            SPWINDOW_Y <= '0';
+        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF (DOTCOUNTERYP = 0) THEN
+                SPWINDOW_Y <= '1';
+            ELSIF( (REG_R9_Y_DOTS = '0' AND DOTCOUNTERYP = 192) OR
+                (REG_R9_Y_DOTS = '1' AND DOTCOUNTERYP = 212) )THEN
+                SPWINDOW_Y <= '0';
+            END IF;
+        END IF;
+    END PROCESS;
+
+
+    -----------------------------------------------------------------------------
     -- [Y_TEST]Yテストステートでないことを示す信号
     -----------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
@@ -638,7 +659,7 @@ BEGIN
                 IF( DOTCOUNTERX = 0 )THEN
                     -- INITIALIZE
                 ELSIF( EIGHTDOTSTATE = "110" )THEN
-                    IF( FF_Y_TEST_EN = '1' AND W_TARGET_SP_EN = '1' AND W_SP_OVERMAP = '1' AND W_SP_OFF = '0' )THEN
+                    IF( SPWINDOW_Y = '1' AND FF_Y_TEST_EN = '1' AND W_TARGET_SP_EN = '1' AND W_SP_OVERMAP = '1' AND W_SP_OFF = '0' )THEN
                         FF_SP_OVERMAP <= '1';
                     END IF;
                 END IF;
@@ -662,7 +683,7 @@ BEGIN
                 ELSIF( EIGHTDOTSTATE = "110" )THEN
                     -- JP: 調査をあきらめたスプライト番号が格納される。OVERMAPとは限らない。
                     -- JP: しかし、すでに OVERMAP で値が確定している場合は更新しない。
-                    IF( FF_Y_TEST_EN = '1' AND W_TARGET_SP_EN = '1' AND W_SP_OVERMAP = '1' AND W_SP_OFF = '0' AND FF_SP_OVERMAP = '0' )THEN
+                    IF( SPWINDOW_Y = '1' AND FF_Y_TEST_EN = '1' AND W_TARGET_SP_EN = '1' AND W_SP_OVERMAP = '1' AND W_SP_OFF = '0' AND FF_SP_OVERMAP = '0' )THEN
                         FF_SP_OVERMAP_NUM <= FF_Y_TEST_SP_NUM;
                     END IF;
                 END IF;
@@ -803,7 +824,7 @@ BEGIN
                                 END IF;
                             WHEN "111" =>
                                 SPPREPARELOCALPLANENUM <= SPPREPARELOCALPLANENUM + 1;
-                                IF( SPPREPARELOCALPLANENUM = 7 ) THEN
+                                IF( (SPPREPARELOCALPLANENUM = 7) OR ((SPPREPARELOCALPLANENUM = 3 AND SPMODE2='0')) ) THEN
                                     SPPREPAREEND <= '1';
                                 END IF;
                             WHEN OTHERS =>
@@ -929,7 +950,7 @@ BEGIN
                             SPCC0FOUNDV := '0';
                         ELSIF( DOTCOUNTERX(4 DOWNTO 0) = 0 ) THEN
                             SPPREDRAWLOCALPLANENUM <= SPPREDRAWLOCALPLANENUM + 1;
-                            IF( SPPREDRAWLOCALPLANENUM = 7 ) THEN
+                            IF( (SPPREDRAWLOCALPLANENUM = 7) OR (SPPREDRAWLOCALPLANENUM = 3 AND SPMODE2 = '0') ) THEN
                                 SPPREDRAWEND <= '1';
                             END IF;
                         END IF;


### PR DESCRIPTION
Games like Zanac that does software sprite multiplexing will have the 5th sprite disappearing because many reasons:

- Never get the VDPS0SPOVERMAPPED on S#0, as it gets masked by REQ_VSYNC_INT_N
- gets the wrong 5th sprite number
- sprites gets tested even outside 1-192/212 lines

This changes allows the game to properly multiplex the 5th and 9th sprites.

check the short video: https://www.youtube.com/watch?v=XbxgC7INQF8

this is not what a real MSX/9918/9938/9958 does. That video was made using MisterFPGA MSX 3.